### PR TITLE
fix circular imports

### DIFF
--- a/sdk/common.py
+++ b/sdk/common.py
@@ -1,0 +1,11 @@
+from private.memory.memory import Size
+
+# Constants
+BLOCK_SIZE = 1 * Size.MB
+ENCRYPTION_OVERHEAD = 28  # 16 bytes for AES-GCM tag, 12 bytes for nonce
+MIN_BUCKET_NAME_LENGTH = 3
+MIN_FILE_SIZE = 127  # 127 bytes
+
+# Exception classes
+class SDKError(Exception):
+    pass

--- a/sdk/connection.py
+++ b/sdk/connection.py
@@ -1,6 +1,6 @@
 import grpc
 import threading
-from ..private.pb import nodeapi_pb2_grpc, ipcnodeapi_pb2_grpc
+from private.pb import nodeapi_pb2_grpc, ipcnodeapi_pb2_grpc
 
 
 class ConnectionPool:

--- a/sdk/sdk.py
+++ b/sdk/sdk.py
@@ -2,26 +2,19 @@ import grpc
 import ipfshttpclient
 from google.protobuf.timestamp_pb2 import Timestamp
 import logging
-from private.memory.memory import Size
 from private.pb import nodeapi_pb2, nodeapi_pb2_grpc, ipcnodeapi_pb2_grpc
 from private.ipc.client import Client
 from private.spclient.spclient import SPClient
 from private.encryption import derive_key
 from typing import List, Optional
 from multiformats import cid
-
-
-BLOCK_SIZE = 1 * Size.MB
-ENCRYPTION_OVERHEAD = 28  # 16 bytes for AES-GCM tag, 12 bytes for nonce
-MIN_BUCKET_NAME_LENGTH = 3
-MIN_FILE_SIZE = 127  # 127 bytes
-
 from .sdk_ipc import IPC
-from .sdk_streaming import StreamingAPI
 from .erasure_code import ErasureCode
+from .common import BLOCK_SIZE, ENCRYPTION_OVERHEAD, MIN_BUCKET_NAME_LENGTH, MIN_FILE_SIZE, SDKError
 
-class SDKError(Exception):
-    pass
+def get_streaming_api():
+    from .sdk_streaming import StreamingAPI
+    return StreamingAPI
 
 class SDK:
     def __init__(self, address: str, max_concurrency: int, block_part_size: int, use_connection_pool: bool,
@@ -62,6 +55,7 @@ class SDK:
             self.conn.close()
 
     def streaming_api(self):
+        StreamingAPI = get_streaming_api()
         return StreamingAPI(self.conn, self.client, self.streaming_erasure_code, self.max_concurrency,
                             self.block_part_size, self.use_connection_pool, self.encryption_key,
                             self.streaming_max_blocks_in_chunk)

--- a/sdk/sdk_ipc.py
+++ b/sdk/sdk_ipc.py
@@ -7,7 +7,7 @@ import concurrent.futures
 from hashlib import sha256
 from typing import List, Optional, Callable, Dict, Any, Union, Tuple
 
-from .sdk import MIN_BUCKET_NAME_LENGTH, SDKError, BLOCK_SIZE, ENCRYPTION_OVERHEAD
+from .common import MIN_BUCKET_NAME_LENGTH, SDKError, BLOCK_SIZE, ENCRYPTION_OVERHEAD
 from .erasure_code import ErasureCode
 from .dag import build_dag, extract_block_data
 from .connection import ConnectionPool

--- a/sdk/sdk_streaming.py
+++ b/sdk/sdk_streaming.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from .sdk import SDKError
+from .common import SDKError
 from .model import FileMeta, FileListItem
 from .erasure_code import ErasureCode
 from private.pb import nodeapi_pb2

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -18,7 +18,7 @@ from sdk.sdk_streaming import (
     FileBlockUpload, FileChunkDownload, FileBlockDownload, AkaveBlockData,
     FilecoinBlockData, ConnectionPool, DAGRoot
 )
-from sdk.sdk import SDKError
+from sdk.common import SDKError
 from sdk.model import FileMeta
 from sdk.erasure_code import ErasureCode
 


### PR DESCRIPTION
This PR resolves a circular import error encountered when running tests or importing the SDK modules. The error occurred because:

- `sdk.py` imports `StreamingAPI` from `sdk_streaming.py` at the top level.
- `sdk_streaming.py` imports `SDKError` from `sdk.py` at the top level.

Fixes #45 :rocket: 