### PR TITLE
feat: adding a configurable retry decorator with exponential backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ env/
 ENV/
 env.bak/
 venv.bak/
+tests/.env
 
 
 # Distribution / packaging

--- a/private/ipc/client.py
+++ b/private/ipc/client.py
@@ -1,7 +1,7 @@
 import time
 from typing import Optional
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from .contracts import StorageContract, AccessManagerContract
@@ -48,7 +48,7 @@ class Client:
 
         # Add POA middleware if needed (common for testnets like Goerli, Sepolia)
         # Consider making this optional based on chain type
-        web3.middleware_onion.inject(geth_poa_middleware, layer=0) 
+        web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0) 
 
         # Create account from private key
         try:
@@ -92,7 +92,7 @@ class Client:
             raise ConnectionError(f"Failed to connect to Ethereum node at {config.dial_uri}")
         
         # Add POA middleware
-        web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+        web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
         try:
             account = Account.from_key(config.private_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ multiformats==0.3.1.post4
 ipld_dag_pb
 
 # Ethereum-related dependencies
-web3==6.11.3
+web3==7.12.0
 eth-account>=0.8.0
 eth-hash>=0.5.2
 eth-keys>=0.4.0

--- a/sdk/connection.py
+++ b/sdk/connection.py
@@ -5,8 +5,8 @@ from private.pb import nodeapi_pb2_grpc, ipcnodeapi_pb2_grpc
 
 
 class ConnectionPool:
-    # by default , retry 3 times with exponential backoff
-    # The init function sets the retries and delay parameters
+    # by default , retry 3 times with exponential backoff.
+    # The init function sets the retries and delay parameters.
     def _retry(func, retries=3, delay=1):
         def wrapper(self, **kwargs):
             current_retry = 0
@@ -23,7 +23,8 @@ class ConnectionPool:
                     current_delay *= 2
             return None
         return wrapper
-
+    
+    # The retries and delay can be configured.
     def __init__(self, retries=3, delay=1):
         self._lock = threading.RLock()
         self._connections = {}

--- a/sdk/connection.py
+++ b/sdk/connection.py
@@ -1,13 +1,38 @@
 import grpc
+import time
 import threading
 from private.pb import nodeapi_pb2_grpc, ipcnodeapi_pb2_grpc
 
 
 class ConnectionPool:
-    def __init__(self):
+    # by default , retry 3 times with exponential backoff
+    # The init function sets the retries and delay parameters
+    def _retry(func, retries=3, delay=1):
+        def wrapper(self, **kwargs):
+            current_retry = 0
+            current_delay = delay
+            while current_retry < retries:
+                try:
+                    return func(self, **kwargs)
+                except Exception as e:
+                    current_retry += 1
+                    if current_retry >= retries:
+                        raise e
+                    print(f"Attempt {current_retry} failed: {e}. Retrying in {current_delay} seconds...")
+                    time.sleep(current_delay)
+                    current_delay *= 2
+            return None
+        return wrapper
+
+    def __init__(self, retries=3, delay=1):
         self._lock = threading.RLock()
         self._connections = {}
         self.use_connection_pool = False
+        self.create_client = self._retry(self.create_client, retries, delay)
+        self.create_ipc_client = self._retry(self.create_ipc_client, retries, delay)
+        self.get = self._retry(self.get, retries, delay)
+        self._new_connection = self._retry(self._new_connection, retries, delay)
+        self.close = self._retry(self.close, retries, delay) 
 
     def create_client(self, addr: str, pooled: bool):
         if pooled:

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,0 +1,1 @@
+PRIVATE_KEY=<your_ethereum_private_key>


### PR DESCRIPTION
## Motivation 

solves #42 

## Description 

Adding the retry decorator with exponential backoff for Network Operations(grpc calls)  such as creating a new client. 
The decorator not only retries the function, but each time with a exponential delay and would raise the exception finally, if all the operations failed. The amount of retries and the delay for each try can be configured when initialising the class `⁠ConnectionPool⁠`

for e.g :-  

if  ⁠ `retries=3` ⁠ and ⁠ `delay=1` ⁠ 

- then if the first attempt in calling the function fails ,after 1 sec the function will be called again.
- if the second attempt fails, now the next time the function is called would be after 2 seconds to wait for a response.  
- finally if the third attempt fails after 4 seconds the final call to function will be made.  
- If this call also fails then the exception will be raised. 


## To-do : 

- [x] add logging 
- [x] checking the configurability 
- [x] testing the implementation
