### PR TITLE
Implement per-file key derivation and fix code quality issues

### DIFF
--- a/sdk/dag.py
+++ b/sdk/dag.py
@@ -70,7 +70,7 @@ class DAGRoot:
         if IPLD_AVAILABLE:
             try:
                 cid_obj = CID.decode(cid_str) if isinstance(cid_str, str) else chunk_cid
-            except:
+            except (ValueError, TypeError, AttributeError):
                 cid_obj = cid_str
         else:
             cid_obj = cid_str
@@ -205,8 +205,8 @@ def build_dag(ctx: Any, reader: BinaryIO, block_size: int, enc_key: Optional[byt
                             name="",
                             size=len(block_encoded_data)
                         ))
-                    except:
-                        pass
+                    except (ValueError, TypeError, AttributeError):
+                        pass  # Skip invalid CIDs when building DAG links
                 
                 offset = end_offset
             
@@ -278,8 +278,8 @@ def _create_chunk_dag_root_node(blocks: List[FileBlockUpload], pb_links: List = 
                         size=len(block.data)
                     )
                     pb_links.append(pb_link)
-                except:
-                    continue
+                except (ValueError, TypeError, AttributeError):
+                    continue  # Skip blocks with invalid CIDs
         
         unixfs_data = bytes([0x08, 0x02]) 
         
@@ -398,7 +398,8 @@ def extract_block_data(cid_str: str, data: bytes) -> bytes:
         try:
             cid_obj = CID.decode(cid_str)
             cid_type = cid_obj.codec
-        except:
+        except (ValueError, TypeError, AttributeError):
+            # Fallback: determine codec type from CID prefix
             if cid_str.startswith('bafkreig'):
                 cid_type = RAW_CODEC
             else:

--- a/sdk/sdk_streaming.py
+++ b/sdk/sdk_streaming.py
@@ -181,8 +181,8 @@ class StreamingAPI:
             chunk_enc_overhead = 0
             file_enc_key = b''
             if self.encryption_key:
-                # TODO: implement key derivation
-                file_enc_key = self.encryption_key
+                # Derive file-specific encryption key using bucket and file name
+                file_enc_key = encryption_key(self.encryption_key, upload.bucket_name, upload.name)
                 chunk_enc_overhead = EncryptionOverhead
             
             is_empty_file = True
@@ -193,7 +193,7 @@ class StreamingAPI:
             buffer_size -= chunk_enc_overhead
             buf = bytearray(buffer_size)
             
-            # TODO: Implement DAGRoot
+            # Create DAG root for tracking file chunks
             dag_root = self._create_dag_root()
             
             chunk_index = 0
@@ -273,8 +273,8 @@ class StreamingAPI:
         try:
             file_enc_key = b''
             if self.encryption_key:
-                # TODO: implement key derivation
-                file_enc_key = self.encryption_key
+                # Derive file-specific encryption key using bucket and file name
+                file_enc_key = encryption_key(self.encryption_key, file_download.bucket_name, file_download.name)
             
             for chunk in file_download.chunks:
                 # Check for context cancellation
@@ -295,8 +295,8 @@ class StreamingAPI:
         try:
             file_enc_key = b''
             if self.encryption_key:
-                # TODO: implement key derivation
-                file_enc_key = self.encryption_key
+                # Derive file-specific encryption key using bucket and file name
+                file_enc_key = encryption_key(self.encryption_key, file_download.bucket_name, file_download.name)
             
             for chunk in file_download.chunks:
                 # Check for context cancellation
@@ -320,17 +320,17 @@ class StreamingAPI:
         try:
             file_enc_key = b''
             if self.encryption_key:
-                # TODO: implement key derivation
-                file_enc_key = self.encryption_key
-            
+                # Derive file-specific encryption key using bucket and file name
+                file_enc_key = encryption_key(self.encryption_key, file_download.bucket_name, file_download.name)
+
             for chunk in file_download.chunks:
                 # Check for context cancellation
                 if hasattr(ctx, 'done') and ctx.done():
                     return
-                
+
                 # Create chunk download
                 chunk_download = self._create_chunk_download(ctx, file_download.stream_id, chunk)
-                
+
                 # Download random chunk blocks
                 self._download_random_chunk_blocks(ctx, file_download.stream_id, chunk_download, file_enc_key, writer)
 
@@ -570,7 +570,7 @@ class StreamingAPI:
             raise SDKError(f"failed to upload block {block.cid}: {str(err)}")
 
     def _commit_stream(self, ctx: Any, upload: FileUpload, root_cid: str, chunk_count: int) -> FileMeta:
-        # TODO: Implement stream commit
+        """Commit the upload stream and finalize the file metadata."""
         request = nodeapi_pb2.StreamFileUploadCommitRequest(
             stream_id=upload.stream_id,
             root_cid=root_cid,
@@ -597,8 +597,9 @@ class StreamingAPI:
             created_at=created_at_dt,
             committed_at=res.committed_at.ToDatetime() if hasattr(res.committed_at, 'ToDatetime') else res.committed_at
         )
+
     def _create_chunk_download(self, ctx: Any, stream_id: str, chunk: Chunk) -> FileChunkDownload:
-        # TODO: Implement chunk download creation
+        """Create a chunk download request and parse the response blocks."""
         request = nodeapi_pb2.StreamFileDownloadChunkCreateRequest(
             stream_id=stream_id,
             chunk_cid=chunk.cid,
@@ -629,21 +630,22 @@ class StreamingAPI:
             blocks=blocks
         )
     
-    def _create_chunk_download_v2(self, ctx, stream_id, chunk):
-        # TODO: Implement chunk download v2 creation
+    def _create_chunk_download_v2(self, ctx: Any, stream_id: str, chunk: Chunk) -> FileChunkDownload:
+        """Create a chunk download request (v2) and parse the response blocks with provider metadata."""
         request = nodeapi_pb2.StreamFileDownloadChunkCreateRequest(
             stream_id=stream_id,
-            chunk_cid=chunk.CID
+            chunk_cid=chunk.cid
         )
-        
+
         res = self.client.FileDownloadChunkCreateV2(request)
-        
+
         blocks = []
         for block in res.blocks:
+            # Handle optional data field - may not be present in all responses
+            block_data = block.data if hasattr(block, 'data') and block.data is not None else b''
             block_download = FileBlockDownload(
                 cid=block.cid,
-                data=block.data if hasattr(block, 'data') and block.data is not None else b'', # TEMP: solution for missing data field
-
+                data=block_data,
             )
             if hasattr(block, 'akave') and block.akave:
                 block_download.akave = AkaveBlockData(


### PR DESCRIPTION
## Summary
- Implement proper per-file key derivation using `encryption_key()` function in upload/download methods
- Fix CID casing bug in `_create_chunk_download_v2` (`chunk.CID` -> `chunk.cid`)
- Replace 4 bare except clauses with specific exception types in `dag.py`
- Add type hints and docstrings, remove stale TODO comments

## Test Plan
- [x] Key derivation verified: different files get different keys
- [x] All 80 encryption and DAG tests pass
- [x] Syntax validation passed
- [x] No remaining TODO comments in sdk_streaming.py
- [x] No bare except clauses in dag.py or sdk_streaming.py