### PR TITLE
Fix/dev enforce ci quality

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,9 +2,9 @@ name: Code Quality
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, develop, dev ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, develop, dev ]
 
 jobs:
   lint:
@@ -29,30 +29,22 @@ jobs:
     - name: Check code formatting with Black
       run: |
         black --check --diff akavesdk/ private/ sdk/ tests/
-      continue-on-error: true
 
     - name: Check import sorting with isort
       run: |
         isort --check-only --diff akavesdk/ private/ sdk/ tests/
-      continue-on-error: true
 
     - name: Lint with flake8
       run: |
-        # Stop the build if there are Python syntax errors or undefined names
-        flake8 akavesdk/ private/ sdk/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Exit-zero treats all errors as warnings
-        flake8 akavesdk/ private/ sdk/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
-      continue-on-error: true
+        flake8 akavesdk/ private/ sdk/ tests/ --count --max-complexity=10 --max-line-length=120 --show-source --statistics
 
     - name: Lint with pylint
       run: |
-        pylint akavesdk/ private/ sdk/ --max-line-length=120 --disable=C0111,R0903,W0212,C0103 --exit-zero
-      continue-on-error: true
+        pylint akavesdk/ private/ sdk/ --max-line-length=120 --disable=C0111,R0903,W0212,C0103
 
     - name: Type check with mypy
       run: |
         mypy akavesdk/ private/ sdk/ --ignore-missing-imports --no-strict-optional
-      continue-on-error: true
 
   security:
     runs-on: ubuntu-latest
@@ -74,14 +66,12 @@ jobs:
 
     - name: Check for security vulnerabilities with Safety
       run: |
-        safety check --json || true
-      continue-on-error: true
+        safety check --json
 
     - name: Security check with Bandit
       run: |
-        bandit -r akavesdk/ private/ sdk/ -ll -f json -o bandit-report.json || true
-        bandit -r akavesdk/ private/ sdk/ -ll || true
-      continue-on-error: true
+        bandit -r akavesdk/ private/ sdk/ -ll -f json -o bandit-report.json
+        bandit -r akavesdk/ private/ sdk/ -ll
 
     - name: Upload Bandit report
       uses: actions/upload-artifact@v4
@@ -107,6 +97,4 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pip-audit
-        pip-audit --desc || true
-      continue-on-error: true
-
+        pip-audit --desc

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,9 +2,9 @@ name: Code Quality
 
 on:
   push:
-    branches: [ main, develop, dev ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, develop, dev ]
+    branches: [ main, dev ]
 
 jobs:
   lint:


### PR DESCRIPTION
Remove continue-on-error from all code quality checks to enforce stricter CI pipeline failures.
Issues: https://github.com/akave-ai/akavesdk-py/issues/97